### PR TITLE
Remove overlay sections for file endpoints

### DIFF
--- a/overlay-remove-V1.yaml
+++ b/overlay-remove-V1.yaml
@@ -8,15 +8,3 @@ actions:
   - target: $["paths"]["/api/v1/channels/{channel_id}"]["delete"]["tags"]
     update:
       - "channels"
-  - target: $["paths"]["/api/v1/sessions/recording/stream"]["get"]["responses"]["200"]["content"]["application/octet-stream"]["schema"]
-    update:
-      "title": "bytes"
-  - target: $["paths"]["/api/v1/sessions/recording/stream"]["get"]["responses"]["200"]["content"]["application/octet-stream"]["schema"]
-    update:
-      "format": "binary"
-  - target: $["paths"]["/api/v1/language_groups/voices/sample"]["post"]["responses"]["200"]["content"]["application/octet-stream"]["schema"]
-    update:
-      "title": "bytes"
-  - target: $["paths"]["/api/v1/language_groups/voices/sample"]["post"]["responses"]["200"]["content"]["application/octet-stream"]["schema"]
-    update:
-      "format": "binary"


### PR DESCRIPTION
After https://github.com/asksyllable/phoenix/pull/3814 is applied in phoenix, the generated OpenAPI specs will have the required fields for file downloads, so these overlays are no longer required